### PR TITLE
Add dry-run Github action

### DIFF
--- a/.github/workflows/dry-run.yaml
+++ b/.github/workflows/dry-run.yaml
@@ -1,0 +1,14 @@
+name: dry-run
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm install build


### PR DESCRIPTION
## What?

Add Github action to run a build for each submitted PR.

## Why?

Adding a "dry run" will ensure that the `build` script is run for **every PR and code change** submitted. This will ensure that linting, formatting, and testing is run and validated before we merge in new changes. This will prevent bugs as we continue to work.

Learn more with the [documentation](https://docs.github.com/en/actions/using-workflows/about-workflows).