### PR TITLE
🚚 move @tsconfig and typescript to root level devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^9.1.1",
+        "@tsconfig/node18": "^18.2.4",
         "eslint": "^8.57.0",
         "turbo": "^1.13.3",
         "typescript": "^5.4.5",
@@ -1991,10 +1992,6 @@
       "dependencies": {
         "@discord-counting-bot/core": "^1.0.0",
         "discord.js": "^14.14.1"
-      },
-      "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
-        "typescript": "^5.4.5"
       }
     },
     "packages/core": {
@@ -2003,10 +2000,6 @@
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.14.1"
-      },
-      "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
-        "typescript": "^5.4.5"
       }
     },
     "packages/registrator": {
@@ -2014,12 +2007,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@discord-counting-bot/core": "*",
+        "@discord-counting-bot/core": "^1.0.0",
         "discord.js": "^14.14.1"
-      },
-      "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
-        "typescript": "^5.4.5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.1.1",
+    "@tsconfig/node18": "^18.2.4",
     "eslint": "^8.57.0",
     "turbo": "^1.13.3",
     "typescript": "^5.4.5",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,10 +11,6 @@
     },
     "author": "",
     "license": "MIT",
-    "devDependencies": {
-      "@tsconfig/node18": "^18.2.4",
-      "typescript": "^5.4.5"
-    },
     "dependencies": {
       "@discord-counting-bot/core": "^1.0.0",
       "discord.js": "^14.14.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,10 +20,6 @@
   },
   "author": "",
   "license": "MIT",
-  "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
-    "typescript": "^5.4.5"
-  },
   "dependencies": {
     "discord.js": "^14.14.1"
   }

--- a/packages/registrator/package.json
+++ b/packages/registrator/package.json
@@ -11,10 +11,6 @@
     },
     "author": "",
     "license": "MIT",
-    "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
-        "typescript": "^5.4.5"
-    },
     "dependencies": {
         "@discord-counting-bot/core": "^1.0.0",
         "discord.js": "^14.14.1"


### PR DESCRIPTION
## What?

Moving the `@tsconfig/node18` and `typescript` dependencies to be listed as `devDependencies` in the root package.json file.

## Why?

For shared dependencies and dependencies which are toolings (e.g. `eslint`), we should maintain the same version of these dependencies across all of the packages in our workspace. We can do this either in each individual package's `package.json` or do it in the root `package.json`. I am proposing we do it in root to make it easier to maintain as time goes on. Rather than needing to update all of the individual packages, we just update the root package and get the updates with additional work.

